### PR TITLE
Introduce `Metric` trait to simplify distance calculation

### DIFF
--- a/benches/ball_tree.rs
+++ b/benches/ball_tree.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ndarray::{aview1, ArrayView};
-use petal_neighbors::BallTree;
+use ndarray::ArrayView;
+use petal_neighbors::{distance, BallTree};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn query_radius(c: &mut Criterion) {
@@ -10,12 +10,12 @@ fn query_radius(c: &mut Criterion) {
     let mut rng = StdRng::from_seed(*b"ball tree query_radius test seed");
     let data: Vec<f64> = (0..n * dim).map(|_| rng.gen()).collect();
     let array = ArrayView::from_shape((n, dim), &data).unwrap();
-    let tree = BallTree::new(array.clone());
+    let tree = BallTree::with_metric(array.clone(), distance::EUCLIDEAN);
     c.bench_function("query_radius", |b| {
         b.iter(|| {
             for i in 0..n {
                 let query = &data[i * dim..i * dim + dim];
-                tree.query_radius(&aview1(query), 0.2);
+                tree.query_radius(query, 0.2);
             }
         })
     });

--- a/src/ball_tree.rs
+++ b/src/ball_tree.rs
@@ -1,4 +1,5 @@
-use ndarray::{Array1, ArrayView1, ArrayView2};
+use crate::distance::Metric;
+use ndarray::{ArrayView1, ArrayView2};
 use std::cmp;
 use std::collections::BinaryHeap;
 use std::convert::TryFrom;
@@ -6,27 +7,21 @@ use std::mem::size_of;
 use std::ops::Range;
 
 /// A data structure for neighbor search in a multi-dimensional space.
-pub struct BallTree<'a> {
+#[derive(Debug)]
+pub struct BallTree<'a, M: Metric> {
     points: ArrayView2<'a, f64>,
     idx: Vec<usize>,
     nodes: Vec<Node>,
-    distance: fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64,
+    metric: M,
 }
 
-impl<'a> BallTree<'a> {
+impl<'a, M: Metric> BallTree<'a, M> {
     /// Builds a ball tree containing the given points.
     ///
     /// # Panics
     ///
     /// Panics if `points` is empty.
-    pub fn new(points: ArrayView2<'a, f64>) -> Self {
-        BallTree::with_distance(points, euclidean_distance)
-    }
-
-    pub fn with_distance(
-        points: ArrayView2<'a, f64>,
-        distance: fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64,
-    ) -> Self {
+    pub fn with_metric(points: ArrayView2<'a, f64>, metric: M) -> Self {
         let n_points: usize = *points
             .shape()
             .first()
@@ -41,12 +36,12 @@ impl<'a> BallTree<'a> {
 
         let mut idx: Vec<usize> = (0..n_points).collect();
         let mut nodes = vec![Node::default(); size];
-        build_subtree(&mut nodes, &mut idx, &points, 0, 0..n_points, distance);
+        build_subtree(&mut nodes, &mut idx, &points, 0, 0..n_points, &metric);
         BallTree {
             points,
             idx,
             nodes,
-            distance,
+            metric,
         }
     }
 
@@ -55,18 +50,30 @@ impl<'a> BallTree<'a> {
     /// # Panics
     ///
     /// Panics if the tree is empty.
-    pub fn query_one(&self, point: &ArrayView1<f64>) -> Neighbor {
+    pub fn query_one<'p, P>(&self, point: P) -> Neighbor
+    where
+        P: 'p + Copy + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+    {
         self.nearest_neighbor_in_subtree(point, 0, std::f64::INFINITY)
             .unwrap()
     }
 
-    pub fn query(&self, point: &ArrayView1<f64>, k: usize) -> Vec<Neighbor> {
+    pub fn query<'p, P>(&self, point: P, k: usize) -> Vec<Neighbor>
+    where
+        P: 'p + Copy + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+    {
         let mut neighbors = BinaryHeap::with_capacity(k);
         self.nearest_k_neighbors_in_subtree(point, 0, std::f64::INFINITY, k, &mut neighbors);
         neighbors.into_sorted_vec()
     }
 
-    pub fn query_radius(&self, point: &ArrayView1<f64>, distance: f64) -> Vec<usize> {
+    pub fn query_radius<'p, P>(&self, point: P, distance: f64) -> Vec<usize>
+    where
+        P: 'p + Copy + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+    {
         self.neighbors_within_radius_in_subtree(point, distance, 0)
     }
 
@@ -75,25 +82,27 @@ impl<'a> BallTree<'a> {
     /// # Panics
     ///
     /// Panics if `root` is out of bound.
-    fn nearest_neighbor_in_subtree(
+    fn nearest_neighbor_in_subtree<'p, P>(
         &self,
-        point: &ArrayView1<f64>,
+        point: P,
         root: usize,
         radius: f64,
-    ) -> Option<Neighbor> {
+    ) -> Option<Neighbor>
+    where
+        P: 'p + Copy + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+    {
         let root_node = &self.nodes[root];
-        let distance = self.distance;
-        let lower_bound = self.nodes[root].distance_lower_bound(point, distance);
+        let lower_bound = self.nodes[root].distance_lower_bound(point, &self.metric);
         if lower_bound > radius {
             return None;
         }
 
         if root_node.is_leaf {
-            let point = ArrayView1::from(point);
             let (min_i, min_dist) = self.idx[root_node.range.clone()].iter().fold(
                 (0, std::f64::INFINITY),
                 |(min_i, min_dist), &i| {
-                    let dist = distance(&point, &self.points.row(i));
+                    let dist = self.metric.distance(point, self.points.row(i));
 
                     if dist < min_dist {
                         (i, dist)
@@ -113,8 +122,8 @@ impl<'a> BallTree<'a> {
         } else {
             let child1 = root * 2 + 1;
             let child2 = child1 + 1;
-            let lb1 = self.nodes[child1].distance_lower_bound(point, distance);
-            let lb2 = self.nodes[child2].distance_lower_bound(point, distance);
+            let lb1 = self.nodes[child1].distance_lower_bound(point, &self.metric);
+            let lb2 = self.nodes[child2].distance_lower_bound(point, &self.metric);
             let (child1, child2) = if lb1 < lb2 {
                 (child1, child2)
             } else {
@@ -140,26 +149,27 @@ impl<'a> BallTree<'a> {
     /// # Panics
     ///
     /// Panics if `root` is out of bound.
-    fn nearest_k_neighbors_in_subtree(
+    fn nearest_k_neighbors_in_subtree<'p, P>(
         &self,
-        point: &ArrayView1<f64>,
+        point: P,
         root: usize,
         radius: f64,
         k: usize,
         neighbors: &mut BinaryHeap<Neighbor>,
-    ) {
-        let distance = self.distance;
+    ) where
+        P: 'p + Copy + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+    {
         let root_node = &self.nodes[root];
-        if root_node.distance_lower_bound(point, distance) > radius {
+        if root_node.distance_lower_bound(point, &self.metric) > radius {
             return;
         }
 
         if root_node.is_leaf {
-            let point = ArrayView1::from(point);
             self.idx[root_node.range.clone()]
                 .iter()
                 .filter_map(|&i| {
-                    let dist = distance(&point, &self.points.row(i));
+                    let dist = self.metric.distance(point, self.points.row(i));
 
                     if dist < radius {
                         Some(Neighbor::new(i, dist))
@@ -179,8 +189,8 @@ impl<'a> BallTree<'a> {
         } else {
             let child1 = root * 2 + 1;
             let child2 = child1 + 1;
-            let lb1 = self.nodes[child1].distance_lower_bound(point, distance);
-            let lb2 = self.nodes[child2].distance_lower_bound(point, distance);
+            let lb1 = self.nodes[child1].distance_lower_bound(point, &self.metric);
+            let lb2 = self.nodes[child2].distance_lower_bound(point, &self.metric);
             let (child1, child2) = if lb1 < lb2 {
                 (child1, child2)
             } else {
@@ -196,20 +206,23 @@ impl<'a> BallTree<'a> {
     /// # Panics
     ///
     /// Panics if `root` is out of bound.
-    fn neighbors_within_radius_in_subtree(
+    fn neighbors_within_radius_in_subtree<'p, P>(
         &self,
-        point: &ArrayView1<f64>,
+        point: P,
         radius: f64,
         root: usize,
-    ) -> Vec<usize> {
+    ) -> Vec<usize>
+    where
+        P: 'p + Copy + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+    {
         let mut neighbors = Vec::new();
-        let distance = self.distance;
         let mut subtrees_to_visit = vec![root];
 
         loop {
             let subroot = subtrees_to_visit.pop().expect("should not be empty");
             let root_node = &self.nodes[subroot];
-            let (lb, ub) = root_node.distance_bounds(point, distance);
+            let (lb, ub) = root_node.distance_bounds(point, &self.metric);
 
             if lb > radius {
                 if subtrees_to_visit.is_empty() {
@@ -222,9 +235,8 @@ impl<'a> BallTree<'a> {
                 neighbors.reserve(root_node.range.end - root_node.range.start);
                 neighbors.extend(self.idx[root_node.range.clone()].iter().cloned());
             } else if root_node.is_leaf {
-                let point = ArrayView1::from(point);
                 neighbors.extend(self.idx[root_node.range.clone()].iter().filter_map(|&i| {
-                    let dist = distance(&point, &self.points.row(i));
+                    let dist = self.metric.distance(point, self.points.row(i));
                     if dist < radius {
                         Some(i)
                     } else {
@@ -287,7 +299,7 @@ impl Eq for Neighbor {}
 #[derive(Clone, Debug)]
 struct Node {
     range: Range<usize>,
-    centroid: Array1<f64>,
+    centroid: Vec<f64>,
     radius: f64,
     is_leaf: bool,
 }
@@ -296,28 +308,34 @@ impl Node {
     /// Computes the centroid of the node.
     #[allow(clippy::cast_precision_loss)] // The precision provided by 54-bit-wide mantissa is
                                           // good enough in computing mean.
-    fn init<D>(&mut self, points: &ArrayView2<f64>, idx: &[usize], distance: D)
-    where
-        D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64,
-    {
-        self.centroid = idx
-            .iter()
-            .fold(Array1::<f64>::zeros(points.ncols()), |mut c, &i| {
-                c += &points.row(i);
-                c
-            })
-            / idx.len() as f64;
+    fn init<M: Metric>(&mut self, points: &ArrayView2<f64>, idx: &[usize], metric: &M) {
+        let mut sum = idx.iter().fold(vec![0_f64; points.ncols()], |mut sum, &i| {
+            for (s, v) in sum.iter_mut().zip(points.row(i)) {
+                *s += v;
+            }
+            sum
+        });
+        sum.iter_mut().for_each(|v| *v /= idx.len() as f64);
+        self.centroid = sum;
 
         self.radius = idx.iter().fold(0., |max, &i| {
-            f64::max(distance(&self.centroid.view(), &points.row(i)), max)
+            f64::max(
+                metric.distance(
+                    &self.centroid,
+                    points.row(i).to_slice().expect("should be contiguous"),
+                ),
+                max,
+            )
         });
     }
 
-    fn distance_bounds<D>(&self, point: &ArrayView1<f64>, distance: D) -> (f64, f64)
+    fn distance_bounds<'p, P, M>(&self, point: P, metric: &M) -> (f64, f64)
     where
-        D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64,
+        P: 'p + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+        M: Metric,
     {
-        let centroid_dist = distance(&point, &self.centroid.view());
+        let centroid_dist = metric.distance(point, &self.centroid);
         let mut lb = centroid_dist - self.radius;
         if lb < 0. {
             lb = 0.;
@@ -326,11 +344,13 @@ impl Node {
         (lb, ub)
     }
 
-    fn distance_lower_bound<D>(&self, point: &ArrayView1<f64>, distance: D) -> f64
+    fn distance_lower_bound<'p, P, M>(&self, point: P, metric: &M) -> f64
     where
-        D: Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64,
+        P: 'p + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'p f64>,
+        M: Metric,
     {
-        let centroid_dist = distance(&point, &self.centroid.view());
+        let centroid_dist = metric.distance(point, &self.centroid);
         let lb = centroid_dist - self.radius;
         if lb < 0. {
             0.
@@ -344,7 +364,7 @@ impl Default for Node {
     fn default() -> Self {
         Self {
             range: (0..0),
-            centroid: Array1::from(vec![]),
+            centroid: Vec::new(),
             radius: 0.,
             is_leaf: false,
         }
@@ -356,22 +376,20 @@ impl Default for Node {
 /// # Panics
 ///
 /// Panics if `root` or `range` is out of range.
-fn build_subtree<D>(
+fn build_subtree<M: Metric>(
     nodes: &mut [Node],
     idx: &mut [usize],
     points: &ArrayView2<f64>,
     root: usize,
     range: Range<usize>,
-    distance: D,
-) where
-    D: Copy + Fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64,
-{
+    metric: &M,
+) {
     let n_nodes = nodes.len();
     let mut root_node = nodes.get_mut(root).expect("root node index out of range");
     root_node.init(
         points,
         &idx.get(range.clone()).expect("invalid subtree range"),
-        distance,
+        metric,
     );
     root_node.range = range.clone();
     let left = root * 2 + 1;
@@ -387,8 +405,8 @@ fn build_subtree<D>(
     halve_node_indices(&mut idx[range.clone()], &col);
 
     let mid = (range.start + range.end) / 2;
-    build_subtree(nodes, idx, points, left, range.start..mid, distance);
-    build_subtree(nodes, idx, points, left + 1, mid..range.end, distance);
+    build_subtree(nodes, idx, points, left, range.start..mid, metric);
+    build_subtree(nodes, idx, points, left + 1, mid..range.end, metric);
 }
 
 /// Divides the node index array into two equal-sized parts.
@@ -417,11 +435,6 @@ fn halve_node_indices(idx: &mut [usize], col: &ArrayView1<f64>) {
             last = cur - 1;
         }
     }
-}
-
-/// Calculates the squared euclidean distance of two points.
-fn euclidean_distance(a: &ArrayView1<f64>, b: &ArrayView1<f64>) -> f64 {
-    (a - b).mapv(|x| x.powi(2)).sum().sqrt()
 }
 
 /// Finds the column with the maximum spread.
@@ -464,6 +477,7 @@ fn max_spread_column(matrix: &ArrayView2<f64>, idx: &[usize]) -> usize {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::distance;
     use ndarray::{aview1, aview2, ArrayView, Axis};
     use rand::prelude::*;
 
@@ -471,16 +485,16 @@ mod test {
     #[should_panic]
     fn ball_tree_empty() {
         let data: [[f64; 0]; 0] = [];
-        let _tree = BallTree::new(aview2(&data));
+        let _tree = BallTree::with_metric(aview2(&data), distance::EUCLIDEAN);
     }
 
     #[test]
-    fn ball_tree() {
+    fn ball_tree_3() {
         let data = [[1., 1.], [1., 1.1], [9., 9.]];
         let view = aview2(&data);
-        let tree = BallTree::new(view);
+        let tree = BallTree::with_metric(view, distance::EUCLIDEAN);
 
-        let point = aview1(&[0., 0.]);
+        let point = [0., 0.];
         let neighbor = tree.query_one(&point);
         assert!(neighbor.approx_eq(&Neighbor {
             idx: 0,
@@ -493,7 +507,7 @@ mod test {
         neighbors.sort_unstable();
         assert_eq!(neighbors, &[0, 1]);
 
-        let point = aview1(&[1.1, 1.2]);
+        let point = [1.1, 1.2];
         let neighbor = tree.query_one(&point);
         assert!(neighbor.approx_eq(&Neighbor {
             idx: 1,
@@ -503,7 +517,7 @@ mod test {
         assert_eq!(neighbors.len(), 1);
         assert!(neighbors[0].approx_eq(&neighbor));
 
-        let point = aview1(&[7., 7.]);
+        let point = [7., 7.];
         let neighbor = tree.query_one(&point);
         assert!(neighbor.approx_eq(&Neighbor {
             idx: 2,
@@ -515,7 +529,7 @@ mod test {
     }
 
     #[test]
-    fn ball_tree2() {
+    fn ball_tree_6() {
         let data = vec![
             [1.0, 2.0],
             [1.1, 2.2],
@@ -525,9 +539,9 @@ mod test {
             [-2.2, 3.1],
         ];
         let view = aview2(&data);
-        let tree = BallTree::new(view);
+        let tree = BallTree::with_metric(view, distance::EUCLIDEAN);
 
-        let point = aview1(&[1., 2.]);
+        let point = [1., 2.];
         let neighbor = tree.query_one(&point);
         assert!(neighbor.approx_eq(&Neighbor {
             idx: 0,
@@ -548,9 +562,9 @@ mod test {
             [1.0, 1.0],
         ];
         let view = aview2(&data);
-        let tree = BallTree::new(view);
+        let tree = BallTree::with_metric(view, distance::EUCLIDEAN);
 
-        let point = aview1(&[1., 2.]);
+        let point = [1., 2.];
         let neighbor = tree.query_one(&point);
         assert_eq!(neighbor.distance, 1f64);
     }
@@ -562,12 +576,12 @@ mod test {
         let mut rng = rand::thread_rng();
         let data: Vec<f64> = (0..40 * DIMENSION).map(|_| rng.gen()).collect();
         let array = ArrayView::from_shape((40, DIMENSION), &data).unwrap();
-        let bt = BallTree::new(array.clone());
+        let bt = BallTree::with_metric(array.clone(), distance::EUCLIDEAN);
         for _ in 0..10 {
             let query: Vec<f64> = (0..DIMENSION).map(|_| rng.gen()).collect();
-            let bt_neighbors = bt.query(&aview1(&query), 5);
+            let bt_neighbors = bt.query(query.as_slice(), 5);
             let naive_neighbors =
-                naive_k_nearest_neighbors(&array, &aview1(&query), 5, euclidean_distance);
+                naive_k_nearest_neighbors(&array, query.as_slice(), 5, distance::EUCLIDEAN);
             for (n_bt, n_naive) in bt_neighbors.iter().zip(naive_neighbors.iter()) {
                 assert_eq!(n_bt.distance, n_naive.distance);
             }
@@ -577,32 +591,31 @@ mod test {
     #[test]
     fn ball_tree_query_radius() {
         let data = vec![[0.], [2.], [3.], [4.], [6.], [8.], [10.]];
-        let bt = BallTree::new(aview2(&data));
+        let bt = BallTree::with_metric(aview2(&data), distance::EUCLIDEAN);
 
-        let neighbors = bt.query_radius(&aview1(&[0.1]), 1.);
+        let neighbors = bt.query_radius(&[0.1], 1.);
         assert_eq!(neighbors, &[0]);
 
-        let mut neighbors = bt.query_radius(&aview1(&[3.2]), 1.);
+        let mut neighbors = bt.query_radius(&[3.2], 1.);
         neighbors.sort_unstable();
         assert_eq!(neighbors, &[2, 3]);
 
-        let neighbors = bt.query_radius(&aview1(&[9.]), 0.9);
+        let neighbors = bt.query_radius(&[9.], 0.9);
         assert!(neighbors.is_empty());
     }
 
     #[test]
     fn node_init() {
-        let distance = euclidean_distance;
         let data = [[0., 1.], [0., 9.], [0., 2.]];
         let idx: [usize; 3] = [0, 1, 2];
         let mut node = Node::default();
-        node.init(&aview2(&data), &idx, distance);
-        assert_eq!(node.centroid, aview1(&[0., 4.]));
+        node.init(&aview2(&data), &idx, &distance::EUCLIDEAN);
+        assert_eq!(node.centroid, [0., 4.]);
         assert_eq!(node.radius, 5.);
 
         let idx: [usize; 2] = [0, 2];
-        node.init(&aview2(&data), &idx, distance);
-        assert_eq!(node.centroid, aview1(&[0., 1.5]));
+        node.init(&aview2(&data), &idx, &distance::EUCLIDEAN);
+        assert_eq!(node.centroid, [0., 1.5]);
     }
 
     #[test]
@@ -673,18 +686,18 @@ mod test {
         assert_eq!(super::max_spread_column(&aview2(&data), &idx), 1);
     }
 
-    fn naive_k_nearest_neighbors<'a>(
+    fn naive_k_nearest_neighbors<'a, M: Metric>(
         neighbors: &ArrayView2<'a, f64>,
-        point: &ArrayView1<f64>,
+        point: &[f64],
         k: usize,
-        distance: fn(&ArrayView1<f64>, &ArrayView1<f64>) -> f64,
+        metric: M,
     ) -> Vec<Neighbor> {
         let mut knn = neighbors
             .axis_iter(Axis(0))
             .enumerate()
             .map(|(i, n)| Neighbor {
                 idx: i,
-                distance: distance(&n, point),
+                distance: metric.distance(n.to_slice().unwrap(), point),
             })
             .collect::<Vec<Neighbor>>();
         knn.sort();

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -1,0 +1,48 @@
+pub trait Metric {
+    fn distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
+    where
+        P: 'a + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'a f64>,
+        Q: 'b + IntoIterator,
+        <Q as IntoIterator>::Item: Copy + Into<&'b f64>;
+
+    /// Calculates the squared euclidean distance of two points.
+    fn reduced_distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
+    where
+        P: 'a + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'a f64>,
+        Q: 'b + IntoIterator,
+        <Q as IntoIterator>::Item: Copy + Into<&'b f64>;
+}
+
+#[derive(Debug)]
+pub struct Euclidean;
+
+impl Metric for Euclidean {
+    fn distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
+    where
+        P: 'a + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'a f64>,
+        Q: 'b + IntoIterator,
+        <Q as IntoIterator>::Item: Copy + Into<&'b f64>,
+    {
+        self.reduced_distance(x1, x2).sqrt()
+    }
+
+    fn reduced_distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
+    where
+        P: 'a + IntoIterator,
+        <P as IntoIterator>::Item: Copy + Into<&'a f64>,
+        Q: 'b + IntoIterator,
+        <Q as IntoIterator>::Item: Copy + Into<&'b f64>,
+    {
+        x1.into_iter()
+            .zip(x2.into_iter())
+            .fold(0_f64, |mut sum, (v1, v2)| {
+                sum += (v1.into() - v2.into()) * (v1.into() - v2.into());
+                sum
+            })
+    }
+}
+
+pub const EUCLIDEAN: Euclidean = Euclidean {};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 mod ball_tree;
+pub mod distance;
 
 pub use ball_tree::{BallTree, Neighbor};


### PR DESCRIPTION
Comparison with master using benches/ball_tree.rs:

```
query_radius            time:   [75.617 us 75.905 us 76.226 us]                         
                        change: [-90.165% -90.067% -89.939%] (p = 0.00 < 0.05)
                        Performance has improved.
```