### PR TITLE
Let `BallTree` take `ArrayBase` rather than `ArrayView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+This file documents recent notable changes to this project. The format of this
+file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2020-04-09
+
+### Changed
+
+- `BallTree` takes `ArrayBase` as its input, instead of `ArrayView`, to allow
+  more types in ndarray.
+
+## [0.1.0] - 2019-11-20
+
+### Added
+
+- A ball tree data structure to find nearest neighbors.
+
+[0.2.0]: https://github.com/petabi/petal-neighbors/compare/0.1.1...0.2.0
+[0.1.0]: https://github.com/petabi/petal-neighbors/tree/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ndarray = "0.13"
 
 [dev-dependencies]
 criterion = "0.3"
-rand = "0.7"
+ndarray-rand = "0.11"
 
 [[bench]]
 name = "ball_tree"

--- a/benches/ball_tree.rs
+++ b/benches/ball_tree.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ndarray::ArrayView;
+use ndarray_rand::rand::{rngs::StdRng, Rng, SeedableRng};
 use petal_neighbors::{distance, BallTree};
-use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn build(c: &mut Criterion) {
     let n = black_box(128);
@@ -12,7 +12,7 @@ fn build(c: &mut Criterion) {
     let array = ArrayView::from_shape((n, dim), &data).unwrap();
     c.bench_function("build", |b| {
         b.iter(|| {
-            BallTree::with_metric(array.clone(), distance::EUCLIDEAN);
+            BallTree::with_metric(&array, distance::EUCLIDEAN);
         })
     });
 }
@@ -24,7 +24,7 @@ fn query_radius(c: &mut Criterion) {
     let mut rng = StdRng::from_seed(*b"ball tree query_radius test seed");
     let data: Vec<f64> = (0..n * dim).map(|_| rng.gen()).collect();
     let array = ArrayView::from_shape((n, dim), &data).unwrap();
-    let tree = BallTree::with_metric(array.clone(), distance::EUCLIDEAN);
+    let tree = BallTree::with_metric(&array, distance::EUCLIDEAN);
     c.bench_function("query_radius", |b| {
         b.iter(|| {
             for i in 0..n {


### PR DESCRIPTION
This allows `BallTree` to support more array types in ndarray.