### PR TITLE
Accept both owned and borrowed array as input to `BallTree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The ownership of the input can be transferred to `BallTree`, which accepts
+  both an owned array and a view.
+
 ## [0.2.0] - 2020-04-09
 
 ### Changed
@@ -18,5 +25,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - A ball tree data structure to find nearest neighbors.
 
+[Unreleased]: https://github.com/petabi/petal-neighbors/compare/0.2.0...master
 [0.2.0]: https://github.com/petabi/petal-neighbors/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/petabi/petal-neighbors/tree/0.1.0

--- a/benches/ball_tree.rs
+++ b/benches/ball_tree.rs
@@ -7,12 +7,12 @@ fn build(c: &mut Criterion) {
     let n = black_box(128);
     let dim = black_box(10);
 
-    let mut rng = StdRng::from_seed(*b"ball tree query_radius test seed");
+    let mut rng = StdRng::from_seed(*b"ball tree build bench test seed ");
     let data: Vec<f64> = (0..n * dim).map(|_| rng.gen()).collect();
     let array = ArrayView::from_shape((n, dim), &data).unwrap();
     c.bench_function("build", |b| {
         b.iter(|| {
-            BallTree::with_metric(&array, distance::EUCLIDEAN);
+            BallTree::with_metric(array, distance::EUCLIDEAN);
         })
     });
 }
@@ -24,7 +24,7 @@ fn query_radius(c: &mut Criterion) {
     let mut rng = StdRng::from_seed(*b"ball tree query_radius test seed");
     let data: Vec<f64> = (0..n * dim).map(|_| rng.gen()).collect();
     let array = ArrayView::from_shape((n, dim), &data).unwrap();
-    let tree = BallTree::with_metric(&array, distance::EUCLIDEAN);
+    let tree = BallTree::with_metric(array, distance::EUCLIDEAN);
     c.bench_function("query_radius", |b| {
         b.iter(|| {
             for i in 0..n {


### PR DESCRIPTION
The ownership of the input can be transferred to `BallTree`, which
accepts both an owned array and a view.