### PR TITLE
Make API more ergonomic and document them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The ownership of the input can be transferred to `BallTree`, which accepts
   both an owned array and a view.
+- An error is returned, rather than a panic, if an empty array is given to
+  construct a `BallTree`.
+- `query_one` has been renamed `query_nearest`.
+- `query` returns indices and distances separately, so that data of the same
+  type are stored together.
 
 ## [0.2.0] - 2020-04-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "petal-neighbors"
 version = "0.2.0"
-description = "A ball tree data structure for neighbor search."
+description = "A ball tree data structure for nearest neighbor search."
+readme = "README.md"
 homepage = "https://github.com/petabi/petal-neighbors"
 repository = "https://github.com/petabi/petal-neighbors"
 license = "Apache-2.0"
@@ -19,6 +20,7 @@ codecov = { repository = "petabi/petal-neighbors", service = "github" }
 ndarray = "0.13"
 
 [dev-dependencies]
+approx = "0.3"
 criterion = "0.3"
 ndarray-rand = "0.11"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # petal-neighbors
 
-An implementation of a ball tree data structure for neighbor search.
+An implementation of a ball tree data structure for nearest neighbor search.
 
+[![crates.io](https://img.shields.io/crates/v/petal-neighbors)](https://crates.io/crates/petal-neighbors)
+[![Documentation](https://docs.rs/petal-neighbors/badge.svg)](https://docs.rs/petal-neighbors)
 [![Coverage Status](https://codecov.io/gh/petabi/petal-neighbors/branch/master/graphs/badge.svg)](https://codecov.io/gh/petabi/petal-neighbors)
 
 ## Requirements

--- a/benches/ball_tree.rs
+++ b/benches/ball_tree.rs
@@ -12,7 +12,7 @@ fn build(c: &mut Criterion) {
     let array = ArrayView::from_shape((n, dim), &data).unwrap();
     c.bench_function("build", |b| {
         b.iter(|| {
-            BallTree::with_metric(array, distance::EUCLIDEAN);
+            BallTree::new(array, distance::EUCLIDEAN).expect("`array` is not empty");
         })
     });
 }
@@ -24,7 +24,7 @@ fn query_radius(c: &mut Criterion) {
     let mut rng = StdRng::from_seed(*b"ball tree query_radius test seed");
     let data: Vec<f64> = (0..n * dim).map(|_| rng.gen()).collect();
     let array = ArrayView::from_shape((n, dim), &data).unwrap();
-    let tree = BallTree::with_metric(array, distance::EUCLIDEAN);
+    let tree = BallTree::new(array, distance::EUCLIDEAN).expect("`array` is not empty");
     c.bench_function("query_radius", |b| {
         b.iter(|| {
             for i in 0..n {

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -1,4 +1,8 @@
+//! Distance metrics.
+
+/// A distance metric for multidimensional points.
 pub trait Metric {
+    /// Calculates the distance between two points.
     fn distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
     where
         P: 'a + IntoIterator,
@@ -6,7 +10,19 @@ pub trait Metric {
         Q: 'b + IntoIterator,
         <Q as IntoIterator>::Item: Copy + Into<&'b f64>;
 
-    /// Calculates the squared euclidean distance of two points.
+    /// Calculates a value that can be used in relative comparison between two
+    /// distances. Therefore, if `distance(p1, q1)` is less than `distance(p2,
+    /// q2)`, then `reduced_distance(p1, q1)` must be less than
+    /// `reduced_distance(p2, q2)`.
+    ///
+    /// This is to provide a more efficient way of distance comparison when
+    /// absolute distance values are not necessary. For example, in the
+    /// Euclidean metric, this function may return a squared distance to avoid
+    /// the overhead of computing the square root.
+    ///
+    /// By default, this calls [`distance`].
+    ///
+    /// [`distance`]: #method.distance
     fn reduced_distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
     where
         P: 'a + IntoIterator,
@@ -15,10 +31,12 @@ pub trait Metric {
         <Q as IntoIterator>::Item: Copy + Into<&'b f64>;
 }
 
+/// The Euclidean distance metric.
 #[derive(Debug)]
 pub struct Euclidean;
 
 impl Metric for Euclidean {
+    /// Calculates the Euclidean distance between two points.
     fn distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
     where
         P: 'a + IntoIterator,
@@ -29,6 +47,7 @@ impl Metric for Euclidean {
         self.reduced_distance(x1, x2).sqrt()
     }
 
+    /// Calculates the squared Euclidean distance between two points.
     fn reduced_distance<'a, 'b, P, Q>(&self, x1: P, x2: Q) -> f64
     where
         P: 'a + IntoIterator,
@@ -45,4 +64,6 @@ impl Metric for Euclidean {
     }
 }
 
+/// An instance of the Euclidean distance metric, to be used as a function
+/// argument.
 pub const EUCLIDEAN: Euclidean = Euclidean {};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 mod ball_tree;
 pub mod distance;
 
-pub use ball_tree::{BallTree, Neighbor};
+pub use ball_tree::BallTree;


### PR DESCRIPTION
- `query_one` has been renamed `query_nearest`.
- `query` functions return indices and distances separately, so that
  data of the same kind are stored in a contiguous memory.