### PR TITLE
Avoid panic when a coordinate is NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `BallTree` and `VantagePointTree` accept an ndarray as a point.
 
+### Fixed
+
+- No longer panics when a coordinate is NaN; the distance from a point with
+  `NaN` in its coordinate and another point is considered greater than the
+  distance between any two points without `NaN` in their coordinates.
+
 ## [0.4.0] - 2020-06-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ codecov = { repository = "petabi/petal-neighbors", service = "github" }
 [dependencies]
 ndarray = "0.13"
 num-traits = "0.2"
+ordered-float = "2"
 thiserror = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
No longer panics when a coordinate is NaN; the distance from a point with
`NaN` in its coordinate and another point is considered greater than the
distance between any two points without `NaN` in their coordinates.